### PR TITLE
Fix CMAKE_ROOT error

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,8 @@ source:
   fn: cmake-3.5.0-win32-x86.zip # [win]
 
 build:
-  number: 2
+  number: 3
+  detect_binary_files_with_prefix: true
 
 test:
   commands:


### PR DESCRIPTION
Without this change, CMake will complain that `CMAKE_ROOT` cannot be found. Error message shown below.

```
CMake Error: Could not find CMAKE_ROOT !!!
CMake has most likely not been installed correctly.
Modules directory not found in
/zopt/conda2/envs/_build/share/cmake-3.5
CMake Error: Error executing cmake::LoadCache(). Aborting.
```

This is because there are hard coded paths in the CMake install referring to the build location. Here we correct that issue by allowing those hard coded paths to be changed.