### PR TITLE
Fix linter errors (add checksums and fix selector spacing)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,11 +3,13 @@ package:
   version: 3.5.0
 
 source:
-  url: https://cmake.org/files/v3.5/cmake-3.5.0.tar.gz  # [not win]
-  fn: cmake-3.5.0.tar.gz # [not win]
-  
-  url: https://cmake.org/files/v3.5/cmake-3.5.0-win32-x86.zip  # [win]
-  fn: cmake-3.5.0-win32-x86.zip # [win]
+  url: https://cmake.org/files/v3.5/cmake-3.5.0.tar.gz                      # [not win]
+  fn: cmake-3.5.0.tar.gz                                                    # [not win]
+  sha256: 92c83ad8a4fd6224cf6319a60b399854f55b38ebe9d297c942408b792b1a9efa  # [not win]
+
+  url: https://cmake.org/files/v3.5/cmake-3.5.0-win32-x86.zip               # [win]
+  fn: cmake-3.5.0-win32-x86.zip                                             # [win]
+  sha256: 807f96230c889b10f2957a47585426af4cdb116a8a77f1caecca83b7d7ab862b  # [win]
 
 build:
   number: 3


### PR DESCRIPTION
Fix https://github.com/conda-forge/cmake-feedstock/issues/4

Fix some linter issues. Add sha256 checksums and correct selector spacing. Also, align selectors to aid in readability.