### PR TITLE
Use conda-forge dependencies

### DIFF
--- a/recipe/SSLTest.cmake
+++ b/recipe/SSLTest.cmake
@@ -1,0 +1,16 @@
+set(FILE_NAME "LICENSE")
+set(DOWNLOAD_URL "https://raw.githubusercontent.com/conda-forge/cmake-feedstock/master/${FILE_NAME}")
+set(EXPECTED_SHA256 "f8c925402b90f74566f71e64eea7bb9d83daac69cde71408ffd6c043be6a4991")
+
+file(DOWNLOAD ${DOWNLOAD_URL} ${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}
+ SHOW_PROGRESS
+ EXPECTED_HASH  SHA256=${EXPECTED_SHA256}
+ STATUS STATUS
+ TLS_VERIFY on )
+
+list( GET STATUS 0 RET )
+list( GET STATUS 1 MESSAGE )
+
+if( NOT RET EQUAL 0 )
+  message(FATAL "Error Downloading file: ${MESSAGE}")
+endif()

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,34 @@
 #!/bin/bash
 
-./bootstrap --prefix=$PREFIX
+
+# FIXME: This is a hack to make sure the environment is activated.
+# The reason this is required is due to the conda-build issue
+# mentioned below.
+#
+# https://github.com/conda/conda-build/issues/910
+#
+source activate "${CONDA_DEFAULT_ENV}"
+
+if [[ `uname` == 'Darwin' ]];
+then
+    export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+else
+    export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
+fi
+
+
+./bootstrap \
+             --prefix="${PREFIX}" \
+             --system-curl \
+             --system-bzip2 \
+             --system-expat \
+             --system-jsoncpp \
+             --system-libarchive \
+             --system-liblzma \
+             --system-zlib \
+             --no-qt-gui \
+             -- \
+             -DCMAKE_BUILD_TYPE:STRING=Release \
+
 make
-make install
+eval ${LIBRARY_SEARCH_VAR}="${PREFIX}/lib" make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 807f96230c889b10f2957a47585426af4cdb116a8a77f1caecca83b7d7ab862b  # [win]
 
 build:
-  number: 3
+  number: 4
   detect_binary_files_with_prefix: true
 
 requirements:        # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,28 @@ build:
   number: 3
   detect_binary_files_with_prefix: true
 
+requirements:        # [unix]
+  build:             # [unix]
+    - toolchain      # [unix]
+    - bzip2 1.0.*    # [unix]
+    - curl           # [unix]
+    - expat          # [unix]
+    - jsoncpp        # [unix]
+    - libarchive     # [unix]
+    - ncurses 5.9*   # [unix]
+    - xz 5.0.*       # [unix]
+    - zlib 1.2.*     # [unix]
+
+  run:               # [unix]
+    - bzip2 1.0.*    # [unix]
+    - curl           # [unix]
+    - expat          # [unix]
+    - jsoncpp        # [unix]
+    - libarchive     # [unix]
+    - ncurses 5.9*   # [unix]
+    - xz 5.0.*       # [unix]
+    - zlib 1.2.*     # [unix]
+
 test:
   commands:
     - cmake --version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - blowekamp
     - groutr
     - jakirkham
     - ocefpaf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,8 +38,11 @@ requirements:        # [unix]
     - zlib 1.2.*     # [unix]
 
 test:
+  files:
+    - SSLTest.cmake
   commands:
     - cmake --version
+    - cmake -V -P SSLTest.cmake
 
 about:
   home: http://www.cmake.org/


### PR DESCRIPTION
Fixes https://github.com/conda-forge/cmake-feedstock/issues/7

Tries to use conda-forge dependencies as much as possible instead of trying to use CMake internally built dependencies. This should speed up the build, improve portability, and fix various subtle issues like not having certs for curl.

This adds some dependencies, but some of them like `bzip2` are not here at conda-forge yet. There are more dependencies we should add like `expat` and `xz`, which don't exist on Windows yet. ~~There are some other dependencies like `jsoncpp` and `libarchive`, which are simply not packaged yet.~~ (EDIT: everything is packaged on UNIX and added as a dependency) Finally, we still need to address pinnings here and probably add a test for using SSL. Other questions include whether we should build this with Qt support as that is an option and could be desirable in some cases.

Feedback welcome on the progress thus far and any of these points that still need to be addressed.

cc @patricksnape @msarahan