### PR TITLE
Added missing plugins folder to fix broken cmake-gui

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,8 @@
 move bin\* %LIBRARY_BIN%\
 if errorlevel 1 exit 1
 
+move plugins %LIBRARY_PREFIX%\
+if errorlevel 1 exit 1
+
 move share %LIBRARY_PREFIX%\
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,13 @@ source:
   fn: cmake-{{ version }}.tar.gz                                                          # [not win]
   sha256: 189ae32a6ac398bb2f523ae77f70d463a6549926cde1544cd9cc7c6609f8b346                # [not win]
 
-  url: https://cmake.org/files/v{{ major_minor }}/cmake-{{ version }}-win32-x86.zip       # [win]
-  fn: cmake-{{ version }}-win32-x86.zip                                                   # [win]
-  sha256: 613eec5a8b2e2c49826e0e8e18f516b6f2b481309ae55925d226ce8ab78b0fba                # [win]
+  url: https://cmake.org/files/v{{ major_minor }}/cmake-{{ version }}-win32-x86.zip       # [win32]
+  fn: cmake-{{ version }}-win32-x86.zip                                                   # [win32]
+  sha256: 613eec5a8b2e2c49826e0e8e18f516b6f2b481309ae55925d226ce8ab78b0fba                # [win32]
+
+  url: https://cmake.org/files/v{{ major_minor }}/cmake-{{ version }}-win64-x64.zip       # [win64]
+  fn: cmake-{{ version }}-win64-x64.zip                                                   # [win64]
+  sha256: 61337a0528fc3902d7f2f7594959aa6aa48a52863dd2da335a0e248b5eb8acaf                # [win64]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
   sha256: 61337a0528fc3902d7f2f7594959aa6aa48a52863dd2da335a0e248b5eb8acaf                # [win64]
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
 
 requirements:        # [unix]


### PR DESCRIPTION
This fixes issue #12. The plugins folder is missing from the installation and this breaks cmake-gui.exe.
