### PR TITLE
bump the build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: 60089b4e05a997edda49f40d4b6db883e0ce5bbe9fdedb5106739dbfe58a8055                # [win]
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
 
 requirements:        # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ test:
   files:
     - SSLTest.cmake
   commands:
+    - cmake
     - cmake --version
     - cmake -V -P SSLTest.cmake
 


### PR DESCRIPTION
Probably some dependencies have changed and cmake is not working anymore.

This should fix https://github.com/conda-forge/cmake-feedstock/issues/14