### PR TITLE
Don't include Qt5 dlls on Windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,9 @@
-move bin\* %LIBRARY_BIN%\
+REM Move only desired files as the downloaded package contains even Qt5 dlls
+move bin\cmake.exe %LIBRARY_BIN%\
+move bin\cmcldeps.exe %LIBRARY_BIN%\
+move bin\cpack.exe %LIBRARY_BIN%\
+move bin\ctest.exe %LIBRARY_BIN%\
+
 if errorlevel 1 exit 1
 
 move share %LIBRARY_PREFIX%\

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: d2ec53ba3e3a12f734ed7127704ff9a83361e7cc6f9a0f0b3e2b56d9868a76b9                # [win]
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
 
 requirements:        # [unix]


### PR DESCRIPTION
This was conflicting with Qt5 packages, essentially replacing
the files and causing crashes.