### PR TITLE
Fix cmake tar command for zip files - fixes #23

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,6 +21,7 @@ fi
              --prefix="${PREFIX}" \
              --system-libs \
              --no-qt-gui \
+             --no-system-libarchive \
              -- \
              -DCMAKE_BUILD_TYPE:STRING=Release \
              -DCMAKE_FIND_ROOT_PATH="${PREFIX}" \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
   sha256: 602d6c0bd458291d21414f94ee24f5bb623f3a623409e15601cc80b9922ff6bd                # [win64]
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
 
 requirements:


### PR DESCRIPTION
I was encountering the same issue described in #23 - cmake from conda-forge fails to correctly extract ZIP archives, while cmake from defaults is fine. This only affected linux.

This PR just adds `--no-system-libarchive` to the build script, to match the build script in anaconda-recipes, as suggested in #23.