### PR TITLE
Update to 3.10.0

### DIFF
--- a/recipe/Windows-Flang-Fortran.cmake
+++ b/recipe/Windows-Flang-Fortran.cmake
@@ -1,0 +1,3 @@
+include(Platform/Windows-MSVC)
+__windows_compiler_msvc(Fortran)
+set(CMAKE_Fortran_COMPILE_OBJECT "<CMAKE_Fortran_COMPILER> ${_COMPILE_Fortran} <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE>")

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,6 +8,11 @@ if errorlevel 1 exit 1
 move bin\ctest.exe %LIBRARY_BIN%\
 if errorlevel 1 exit 1
 
+REM Just make sure that no dll exists here so we can detect when cmake people
+REM decide to change the dependency.
+dir bin\*.dll
+if errorlevel 0 exit 1
+
 move share %LIBRARY_PREFIX%\
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -16,3 +16,5 @@ if errorlevel 1 exit 1
 
 move share %LIBRARY_PREFIX%\
 if errorlevel 1 exit 1
+
+cp %RECIPE_DIR%\Windows-Flang-Fortran.cmake %LIBRARY_PREFIX%\share\cmake-3.10\Modules\Platform\

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -11,7 +11,7 @@ if errorlevel 1 exit 1
 REM Just make sure that no dll exists here so we can detect when cmake people
 REM decide to change the dependency.
 dir bin\*.dll
-if errorlevel 0 exit 1
+if not errorlevel 1 exit 1
 
 move share %LIBRARY_PREFIX%\
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,12 +8,6 @@ if errorlevel 1 exit 1
 move bin\ctest.exe %LIBRARY_BIN%\
 if errorlevel 1 exit 1
 
-REM This file needs to be in a separate package.
-REM Just make sure that it exists here so we can detect when cmake people
-REM decide to change the dependency.
-dir bin\msvcr120.dll
-if errorlevel 1 exit 1
-
 move share %LIBRARY_PREFIX%\
 if errorlevel 1 exit 1
 

--- a/recipe/flang-fix.patch
+++ b/recipe/flang-fix.patch
@@ -1,0 +1,89 @@
+From 72d27964b92ddb4d8ee85e32a27d0e56d642ec1c Mon Sep 17 00:00:00 2001
+From: Isuru Fernando <isuruf@gmail.com>
+Date: Mon, 30 Oct 2017 19:51:23 -0500
+Subject: [PATCH] Flang: Identify as simulating MSVC on Windows
+
+In `CMakeFortranCompilerId.F.in`, take the `_MSC_VER` out of the
+Intel-specific block so it will trigger for other compilers like Flang.
+In `Compiler/Clang.cmake`, switch off Fortran too.
+---
+ Modules/CMakeFortranCompilerId.F.in | 41 ++++++++++++++++++++---------------------
+ Modules/Compiler/Clang.cmake        |  3 ++-
+ 2 files changed, 22 insertions(+), 22 deletions(-)
+
+diff --git a/share/cmake-3.10/Modules/CMakeFortranCompilerId.F.in b/share/cmake-3.10/Modules/CMakeFortranCompilerId.F.in
+index 49789f1..da3d953 100644
+--- a/share/cmake-3.10/Modules/CMakeFortranCompilerId.F.in
++++ b/share/cmake-3.10/Modules/CMakeFortranCompilerId.F.in
+@@ -2,6 +2,26 @@
+ #if 0
+ ! Identify the compiler
+ #endif
++#if defined(_MSC_VER)
++       PRINT *, 'INFO:simulate[MSVC]'
++# if _MSC_VER >= 1900
++       PRINT *, 'INFO:simulate_version[019.00]'
++# elif _MSC_VER >= 1800
++       PRINT *, 'INFO:simulate_version[018.00]'
++# elif _MSC_VER >= 1700
++       PRINT *, 'INFO:simulate_version[017.00]'
++# elif _MSC_VER >= 1600
++       PRINT *, 'INFO:simulate_version[016.00]'
++# elif _MSC_VER >= 1500
++       PRINT *, 'INFO:simulate_version[015.00]'
++# elif _MSC_VER >= 1400
++       PRINT *, 'INFO:simulate_version[014.00]'
++# elif _MSC_VER >= 1310
++       PRINT *, 'INFO:simulate_version[013.01]'
++# else
++       PRINT *, 'INFO:simulate_version[013.00]'
++# endif
++#endif
+ #if defined(__INTEL_COMPILER) || defined(__ICC)
+         PRINT *, 'INFO:compiler[Intel]'
+ # define COMPILER_VERSION_MAJOR DEC(__INTEL_COMPILER/100)
+@@ -14,27 +34,6 @@
+ # if defined(__INTEL_COMPILER_BUILD_DATE)
+ #  define COMPILER_VERSION_TWEAK DEC(__INTEL_COMPILER_BUILD_DATE)
+ # endif
+-
+-# if defined(_MSC_VER)
+-        PRINT *, 'INFO:simulate[MSVC]'
+-#  if _MSC_VER >= 1900
+-        PRINT *, 'INFO:simulate_version[019.00]'
+-#  elif _MSC_VER >= 1800
+-        PRINT *, 'INFO:simulate_version[018.00]'
+-#  elif _MSC_VER >= 1700
+-        PRINT *, 'INFO:simulate_version[017.00]'
+-#  elif _MSC_VER >= 1600
+-        PRINT *, 'INFO:simulate_version[016.00]'
+-#  elif _MSC_VER >= 1500
+-        PRINT *, 'INFO:simulate_version[015.00]'
+-#  elif _MSC_VER >= 1400
+-        PRINT *, 'INFO:simulate_version[014.00]'
+-#  elif _MSC_VER >= 1310
+-        PRINT *, 'INFO:simulate_version[013.01]'
+-#  else
+-        PRINT *, 'INFO:simulate_version[013.00]'
+-#  endif
+-# endif
+ #elif defined(__SUNPRO_F95)
+         PRINT *, 'INFO:compiler[SunPro]'
+ # define COMPILER_VERSION_MAJOR HEX(__SUNPRO_F95>>8)
+diff --git a/share/cmake-3.10/Modules/Compiler/Clang.cmake b/share/cmake-3.10/Modules/Compiler/Clang.cmake
+index 9f5e921..7ce1adb 100644
+--- a/share/cmake-3.10/Modules/Compiler/Clang.cmake
++++ b/share/cmake-3.10/Modules/Compiler/Clang.cmake
+@@ -11,7 +11,8 @@ set(__COMPILER_CLANG 1)
+ include(Compiler/CMakeCommonCompilerMacros)
+ 
+ if("x${CMAKE_C_SIMULATE_ID}" STREQUAL "xMSVC"
+-    OR "x${CMAKE_CXX_SIMULATE_ID}" STREQUAL "xMSVC")
++    OR "x${CMAKE_CXX_SIMULATE_ID}" STREQUAL "xMSVC"
++    OR "x${CMAKE_Fortran_SIMULATE_ID}" STREQUAL "xMSVC")
+   macro(__compiler_clang lang)
+   endmacro()
+ else()
+--
+libgit2 0.26.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,10 @@ source:
   fn: cmake-{{ version }}-win64-x64.zip                                                   # [win64]
   sha256: b530586b92241bc10aaaaa391bc9b8f1ae830a676050f9f5e6003d2ce6085abc                # [win64]
 
+  patches:
+    # Revert the whole commit in 3.11
+    - flang-fix.patch   # [win]
+
 build:
   number: 0
   detect_binary_files_with_prefix: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,6 @@ requirements:
     - zlib 1.2.*     # [unix]
     - libuv          # [unix]
     - rhash          # [unix]
-    - vs2013_runtime  # [win]
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set major_minor = "3.9" %}
-{% set version = major_minor + ".6" %}
+{% set major_minor = "3.10" %}
+{% set version = major_minor + ".0" %}
 
 package:
   name: cmake
@@ -8,15 +8,15 @@ package:
 source:
   url: https://cmake.org/files/v{{ major_minor }}/cmake-{{ version }}.tar.gz              # [not win]
   fn: cmake-{{ version }}.tar.gz                                                          # [not win]
-  sha256: 7410851a783a41b521214ad987bb534a7e4a65e059651a2514e6ebfc8f46b218                # [not win]
+  sha256: b3345c17609ea0f039960ef470aa099de9942135990930a57c14575aae884987                # [not win]
 
   url: https://cmake.org/files/v{{ major_minor }}/cmake-{{ version }}-win32-x86.zip       # [win32]
   fn: cmake-{{ version }}-win32-x86.zip                                                   # [win32]
-  sha256: 8dd4b6c35afa8e0c044789b55645327cc4bb75276f87c6758f9997c08f559256                # [win32]
+  sha256: dce666e897f95a88d3eed6cddd1faa3f44179d519b33ca6065b385bbc7072419                # [win32]
 
   url: https://cmake.org/files/v{{ major_minor }}/cmake-{{ version }}-win64-x64.zip       # [win64]
   fn: cmake-{{ version }}-win64-x64.zip                                                   # [win64]
-  sha256: fa667bf658fa526e4e2489a9704f83f851e5ded66a18904424ba1b8505fd4dc0                # [win64]
+  sha256: b530586b92241bc10aaaaa391bc9b8f1ae830a676050f9f5e6003d2ce6085abc                # [win64]
 
 build:
   number: 0


### PR DESCRIPTION
cmake 3.10.0 adds support for Flang on unix. cmake master adds support for Flang on windows. This PR adds the patches from cmake master to support Flang on windows.