### PR TITLE
Removing C++17 setting on macOS 10.9

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,21 +1,6 @@
 #!/bin/sh
 set -ex
 
-if [[ "$target_platform" == osx* ]]; then
-  # When MACOSX_DEPLOYMENT_TARGET is set to 10.9, libc++ headers
-  # will only use symbols from libc++.dylib version shipped in 10.9
-  # and error out if newer features are used.
-  # Since we are using our own libc++.dylib, we don't have that
-  # restriction. Setting _LIBCPP_DISABLE_AVAILABILITY removes this
-  # error. This flag might be best added in the compiler activation
-  # package, but it's safe keeping this just for this recipe until
-  # the consequences are understood
-  # See https://bugzilla.mozilla.org/show_bug.cgi?id=1573733
-  export CPPFLAGS="$CPPFLAGS -D_LIBCPP_DISABLE_AVAILABILITY=1"
-  export CFLAGS="$CFLAGS -D_LIBCPP_DISABLE_AVAILABILITY=1"
-  export CXXFLAGS="$CXXFLAGS -D_LIBCPP_DISABLE_AVAILABILITY=1"
-fi
-
 ./bootstrap \
              --verbose \
              --prefix="${PREFIX}" \
@@ -31,8 +16,9 @@ fi
              -DCURSES_INCLUDE_PATH="${PREFIX}/include" \
              -DBUILD_CursesDialog=ON \
              -DCMake_HAVE_CXX_MAKE_UNIQUE:INTERNAL=FALSE \
-             -DCMAKE_PREFIX_PATH="${PREFIX}" \
-             -DCMAKE_CXX_STANDARD:STRING=17
+             -DCMAKE_PREFIX_PATH="${PREFIX}"
+             
+# CMake automatically selects the highest C++ standard available
 
 make install -j${CPU_COUNT}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 51600879885967ea5fbfae9352d5de88de39d9c2cb1cb44e2ea2c374da35b182
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win and vc<14]
   ignore_run_exports:
     - vc


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Closes #101.