### PR TITLE
update hash for updated licence file

### DIFF
--- a/recipe/SSLTest.cmake
+++ b/recipe/SSLTest.cmake
@@ -1,6 +1,6 @@
 set(FILE_NAME "LICENSE.txt")
 set(DOWNLOAD_URL "https://raw.githubusercontent.com/conda-forge/cmake-feedstock/master/${FILE_NAME}")
-set(EXPECTED_SHA256 "1b17a4bbffec8473f2c0be83f697c2e533f8e1170ed74525ceeee24ddd887afd")
+set(EXPECTED_SHA256 "b5904c52eaee178d332cc0cb2e3795f68af62a72bfb090ea32c493abd88af0d6")
 
 file(DOWNLOAD ${DOWNLOAD_URL} ${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}
  SHOW_PROGRESS

--- a/recipe/SSLTest.cmake
+++ b/recipe/SSLTest.cmake
@@ -1,5 +1,5 @@
 set(FILE_NAME "LICENSE.txt")
-set(DOWNLOAD_URL "https://raw.githubusercontent.com/conda-forge/cmake-feedstock/master/${FILE_NAME}")
+set(DOWNLOAD_URL "https://raw.githubusercontent.com/conda-forge/cmake-feedstock/968a712d28a374c73e20b8b8b0115e8027018870/${FILE_NAME}")
 set(EXPECTED_SHA256 "b5904c52eaee178d332cc0cb2e3795f68af62a72bfb090ea32c493abd88af0d6")
 
 file(DOWNLOAD ${DOWNLOAD_URL} ${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}


### PR DESCRIPTION
Fixes spurious failure in ssl test caused by
5ad09538f9bbe074f7f9f041cf6d2f41fa205d83

