### PR TITLE
Set default value for CMAKE_INSTALL_PREFIX

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,0 +1,7 @@
+@echo off
+
+if "%CONDA_BUILD%" EQU "1" (
+    set CMAKE_INSTALL_PREFIX=%PREFIX%\Library
+) else (
+    set CMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library
+)

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,0 +1,16 @@
+if [[ $CONDA_BUILD -eq 1 ]];
+then
+    if [[ ! -z $COMSPEC ]];
+    then
+        export CMAKE_INSTALL_PREFIX=$PREFIX/Library
+    else
+        export CMAKE_INSTALL_PREFIX=$PREFIX
+    fi;
+else
+    if [[ ! -z $COMSPEC ]];
+    then
+        export CMAKE_INSTALL_PREFIX=$CONDA_PREFIX/Library
+    else
+        export CMAKE_INSTALL_PREFIX=$CONDA_PREFIX
+    fi;
+fi;

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -30,3 +30,15 @@ if errorlevel 1 exit 1
 
 ctest --test-dir . --output-on-failure -j%CPU_COUNT% -R "CTestTestParallel|DOWNLOAD"
 if errorlevel 1 exit 1
+
+setlocal EnableDelayedExpansion
+:: Generate and copy the [de]activate scripts to %PREFIX%\etc\conda\[de]activate.d.
+:: This will allow them to be run on environment activation.
+for %%F in (activate deactivate) DO (
+    if not exist %PREFIX%\etc\conda\%%F.d mkdir %PREFIX%\etc\conda\%%F.d
+    copy %RECIPE_DIR%\%%F.bat %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.bat
+    if %errorlevel% neq 0 exit /b %errorlevel%
+
+    copy %RECIPE_DIR%\%%F.sh %PREFIX%\etc\conda\%%F.d\%PKG_NAME%_%%F.sh
+    if %errorlevel% neq 0 exit /b %errorlevel%
+)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,3 +22,11 @@ cmake --build . --target install -j${CPU_COUNT}
 if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then
   ctest --output-on-failure -j${CPU_COUNT} -R "CTestTestParallel|DOWNLOAD"
 fi
+
+# Generate and copy the [de]activate scripts to $PREFIX/etc/conda/[de]activate.d.
+# This will allow them to be run on environment activation.
+for CHANGE in "activate" "deactivate"
+do
+    mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
+    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
+done

--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -1,0 +1,3 @@
+@echo off
+
+set CMAKE_INSTALL_PREFIX=

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,0 +1,1 @@
+unset CMAKE_INSTALL_PREFIX

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: a0669630aae7baa4a8228048bf30b622f9e9fd8ee8cedb941754e9e38686c778
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports:
     - vc
 


### PR DESCRIPTION
CMake 3.29 added support for specifying the default for `CMAKE_INSTALL_PREFIX` via an environment variable, called `CMAKE_INSTALL_PREFIX` (see https://gitlab.kitware.com/cmake/cmake/-/issues/25023 and https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9200).

Without setting the `CMAKE_INSTALL_PREFIX` env variable, the default install prefix is `/usr/local` on *nix or some path based on `C:\Program Files\` on Windows. In any case, this default values do not make sense w.r.t. to the CONDA_PREFIX . 

This PR adds activation scripts to the cmake package to set the `CMAKE_INSTALL_PREFIX` env variable (and hence the default value of `CMAKE_INSTALL_PREFIX` to a useful value, according to the following logic:
* If on *nix, set `CMAKE_INSTALL_PREFIX` to `$CONDA_PREFIX`, or `$PREFIX` when under `conda-build`
* If on Windows, set `CMAKE_INSTALL_PREFIX` to `%CONDA_PREFIX%\Library`, or `%PREFIX%\Library` when under `conda-build`

The main advantage of this is that now downloading and installing a project via `git clone https://github.com/someorg/someproj && cmake -Bbuild -Ssomeproj && cmake --build ./build && cmake --install ./build` while automatically installs the cmake project in the environment, a bit like on Python `git clone https://github.com/someorg/someproj && pip install --no-deps -e ./someproj` installs the Python package in the environment.

If `CMAKE_INSTALL_PREFIX` is set via command line, the value specified via command line take the precedence over the default value set via the `CMAKE_INSTALL_PREFIX` environment variable, so this modification should be backward compatible with all conda recipes or any other cmake use that sets `CMAKE_INSTALL_PREFIX` either via `$CMAKE_ARGS` or explicitly.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
